### PR TITLE
fix bug #1688: Check ISO version before install Mevoco

### DIFF
--- a/zstackbuild/build.properties
+++ b/zstackbuild/build.properties
@@ -104,3 +104,6 @@ vyos.source=${zstack_build_root}/zstack-vyos
 
 build.zstack.war.script=${zstackbuild.scripts}/build_zstack_war.sh
 build.premium.war.script=${zstackbuild.scripts}/build_premium_war.sh
+
+zstack.distro.source=${zstack_build_root}/zstack-distro
+zstack.distro.build_version=${build_version}

--- a/zstackbuild/build.xml
+++ b/zstackbuild/build.xml
@@ -77,6 +77,7 @@
     <import file="${basedir}/projects/zstack-agent.xml" optional="false" />
     <import file="${basedir}/projects/zstack-store.xml" optional="false" />
     <import file="${basedir}/projects/zstack-vyos.xml" optional="false" />
+    <import file="${basedir}/projects/zstack-distro.xml" optional="false" />
     <import file="${basedir}/projects/build-pypi-source.xml" optional="false" />
     <import file="${basedir}/projects/install-all-zstack-agents-to-local-virtualenv.xml" optional="false" />
 
@@ -244,6 +245,9 @@
             </sequential>
             <sequential>
                 <antcall target="build-zstack-vyos"/>
+            </sequential>
+            <sequential>
+                <antcall target="checkout-zstack-distro"/>
             </sequential>
         </parallel>
     </target>

--- a/zstackbuild/projects/zstack-buildallinone.xml
+++ b/zstackbuild/projects/zstack-buildallinone.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="zstack all in one package builder" basedir="../">
     <property name="target.license.file" location="${allinone.dir}/zstack-license" />
+    <property name="zstack.iso.version" location="${zstack.distro.source}/mkiso/ISO_VERSION" />
+
     <target name="all-in-one-package" >
         <copy file="${zstack.install}" todir="${build.dir}" />
         <copy file="${war.file}" todir="${allinone.dir}" />
@@ -14,7 +16,16 @@
         <copy file="${license.file}" tofile="${target.license.file}" />
     </target>
 
-    <target name="build-centos-offline" depends="copy-license-file">
+    <target name="check-iso-version-exists">
+        <available file="${zstack.iso.version}"  property="iso.version.exists"/>
+    </target>
+
+    <target name="copy-iso-version" depends="check-iso-version-exists" if="iso.version.exists">
+        <echo message="copy ISO_VERSION to ${allinone.bin.dir}" />
+        <copy file="${zstack.iso.version}" todir="${allinone.bin.dir}" />
+    </target>
+
+    <target name="build-centos-offline" depends="copy-license-file, check-iso-version-exists">
         <copy file="${war.file}" todir="${allinone.dir}" />
         <echo message="copy apache-tomcat to ${allinone.file}" />
         <copy file="${apachetomcat.pkg}" todir="${allinone.dir}" />
@@ -23,6 +34,7 @@
         <makeDir dir="${allinone.bin.dir}" />
         <move file="${allinone.file}" todir="${allinone.bin.dir}" />
         <copy file="${zstack.install}" todir="${allinone.bin.dir}" />
+
         <exec executable="bash" dir="${allinone.bin.dir}" failonerror="true">
             <arg value="${offline.bin.gen.setup.script}" />
             <arg value="${product.name}" />
@@ -36,6 +48,18 @@
             <arg value="${product.version}" />
             <arg value="${allinone.bin.product.title}" />
         </exec>
+
+        <fail message="ISO_VERSION file does not exists.">
+            <condition>
+                <and>
+                    <isset property="build_war_flag" />
+                    <not>
+                        <isset property="iso.version.exists" />
+                    </not>
+                </and>
+            </condition>
+        </fail>
+        <antcall target="copy-iso-version" />
 
         <tar destfile="${allinone.offline.file}" basedir="${allinone.bin.dir}" />
         <exec executable="bash" dir="${build.dir}" failonerror="true">

--- a/zstackbuild/projects/zstack-distro.xml
+++ b/zstackbuild/projects/zstack-distro.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project name="zstack-distro checkouter" basedir="../">
+    <condition property="source.exists">
+        <available file="${zstack.distro.source}" type="dir"/>
+    </condition>
+
+    <condition property="needs.check">
+        <or>
+            <isset property="build_war_flag"/>
+            <isset property="source.exists" />
+        </or>
+    </condition>
+
+    <target name="checkout-zstack-distro" if="needs.check">
+        <checkFile file="${zstack.distro.source}" />
+        <exec executable="git" dir="${zstack.distro.source}" failonerror="true">
+            <arg value="checkout" />
+            <arg value="${zstack.distro.build_version}" />
+        </exec>
+    </target>
+</project>


### PR DESCRIPTION
- 打包installer.bin时，要将zstack-distro库克隆至zstack-utility等的同级目录，并checkout至相应分支
- 打包Bin包过程中，拷贝zstack-distro/mkiso/ISO_VERSION至install.sh同级目录
- 安装Bin包过程中，如果是Mevoco，需要比对包中的ISO_VERSION与/opt/zstack-dvd/ISO_VERSION是否一致，若不一致，则提示用户下载对应版本的ISO升级系统；如果是ZStack，则不做版本检查。