### PR TITLE
Fix bug #1845: Provide a way to track OS version (mapping to ISO version)

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -1962,9 +1962,9 @@ get_zstack_repo(){
 }
 
 check_iso_version() {
-	[ ! -f "ISO_VERSION" ] && return 1
-	[ ! -f "/opt/zstack-dvd/ISO_VERSION" ] && return 1
-	diff ISO_VERSION /opt/zstack-dvd/ISO_VERSION >/dev/null 2>&1
+	[ ! -f ".repo_version" ] && return 1
+	[ ! -f "/opt/zstack-dvd/.repo_version" ] && return 1
+	diff .repo_version /opt/zstack-dvd/.repo_version >/dev/null 2>&1
 	return $?
 }
 

--- a/zstackbuild/projects/zstack-buildallinone.xml
+++ b/zstackbuild/projects/zstack-buildallinone.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="zstack all in one package builder" basedir="../">
     <property name="target.license.file" location="${allinone.dir}/zstack-license" />
-    <property name="zstack.iso.version" location="${zstack.distro.source}/mkiso/ISO_VERSION" />
+    <property name="zstack.iso.version" location="${zstack.distro.source}/mkiso/.repo_version" />
 
     <target name="all-in-one-package" >
         <copy file="${zstack.install}" todir="${build.dir}" />
@@ -21,7 +21,7 @@
     </target>
 
     <target name="copy-iso-version" depends="check-iso-version-exists" if="iso.version.exists">
-        <echo message="copy ISO_VERSION to ${allinone.bin.dir}" />
+        <echo message="copy .repo_version to ${allinone.bin.dir}" />
         <copy file="${zstack.iso.version}" todir="${allinone.bin.dir}" />
     </target>
 
@@ -49,7 +49,7 @@
             <arg value="${allinone.bin.product.title}" />
         </exec>
 
-        <fail message="ISO_VERSION file does not exists.">
+        <fail message=".repo_version file does not exists.">
             <condition>
                 <and>
                     <isset property="build_war_flag" />


### PR DESCRIPTION
[@爽提出应该在记录离线源版本的同时，也要记录OS的版本。](https://github.com/zxwing/premium/issues/1845)

将原来的ISO_VERSION文件改为隐藏文件.repo_version，以免用户可以轻易绕过检查；
`zstack-enterprise-manager.rpm`或`zstack-community-manager.rpm`会安装`/etc/zstack-release`文件，该文件内容分三部分：
- REPOVERSION，同.repo_version中的内容，表示离线源的版本
- ISOVERSION，记录ISO名称，比如`ZStack-Community-DVD-x86_64-1.9.0`
- BUILDSTAMP，记录ISO的构造时间，比如`20170114101010`