### PR TITLE
set root volume whose deviceId is 0 to be booted first

### DIFF
--- a/kvmagent/kvmagent/plugins/vm_plugin.py
+++ b/kvmagent/kvmagent/plugins/vm_plugin.py
@@ -2427,8 +2427,6 @@ class Vm(object):
                     raise Exception('unknown volume deviceType: %s' % v.deviceType)
 
                 assert vol is not None, 'vol cannot be None'
-                if v.deviceId == 0:
-                    e(vol, 'boot', None, {'order': '1'})
                 volume_qos(vol)
                 devices.append(vol)
 


### PR DESCRIPTION
For https://github.com/zxwing/premium/issues/1563 (reverted from commit 206cbc4cbee8cc0d442e21263981e94b83fe51d4)