### PR TITLE
Fix bug #1858: Do not re-install general libs that are already instal…

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -870,6 +870,7 @@ is_install_general_libs_rh(){
 
 	missing_list=`LANG=en_US.UTF-8 && rpm -q $deps_list | grep 'not installed' | awk 'BEGIN{ORS=" "}{ print $2 }'`
 
+	[ x"$ZSTACK_OFFLINE_INSTALL" = x'y' ] && missing_list=$deps_list
 	if [ ! -z "$missing_list" ]; then
 		if [ ! -z $ZSTACK_YUM_REPOS ]; then
 			yum --disablerepo="*" --enablerepo=$ZSTACK_YUM_REPOS clean metadata >/dev/null 2>&1


### PR DESCRIPTION
最初为了防止安装/升级ZStack时触发`yum update`，增加了一条限制，即：对于ZStack的依赖包，如果系统中已经存在，则不对其执行YUM操作。
但是当新版ZStack需要某依赖包升级时，即使执行`zstack-repo-upgrade.sh`升级了本地源，依然无法安装新版依赖包，从而导致新版ZStack无法正常运行。
实际上，**离线升级**应该是被允许的。
当用户不带参数或者通过`-o`或`-u`来安装/升级Mevoco时，代码中会设置`ZSTACK_OFFLINE_INSTALL = y`，
因此在代码中对该值进行判断，若是`y`则应该对整个依赖列表进行更新；若不是'y'，则仅对新增依赖包进行安装。