### PR TITLE
Fix fusionstor clone takes more than 10 seconds issue.

### DIFF
--- a/fusionstorprimarystorage/fusionstorprimarystorage/fusionstoragent.py
+++ b/fusionstorprimarystorage/fusionstorprimarystorage/fusionstoragent.py
@@ -319,7 +319,7 @@ class FusionstorAgent(object):
         dst_path = self._normalize_install_path(cmd.dstPath)
 
         _pool = os.path.dirname(dst_path)
-        if not lichbd.lichbd_file_exist(_pool):
+        if not lichbd.lichbd_pool_exist(_pool):
             lichbd.lichbd_mkpool(_pool)
 
         lichbd.lichbd_snap_clone(src_path, dst_path)
@@ -385,7 +385,7 @@ class FusionstorAgent(object):
         size = "%dM" % (size_M)
 
         _pool = os.path.dirname(path)
-        if not lichbd.lichbd_file_exist(_pool):
+        if not lichbd.lichbd_pool_exist(_pool):
             lichbd.lichbd_mkpool(_pool)
         lichbd.lichbd_create_raw(path, size)
 

--- a/zstacklib/zstacklib/utils/lichbd.py
+++ b/zstacklib/zstacklib/utils/lichbd.py
@@ -310,6 +310,17 @@ def lichbd_file_exist(path):
             raise_exp(shellcmd)
     return True
 
+def lichbd_pool_exist(path):
+    shellcmd = call_try("lichfs --stat /default/%s" % (path))
+    if shellcmd.return_code != 0:
+        if shellcmd.return_code == 2:
+            return False
+        elif shellcmd.return_code == 21:
+            return True
+        else:
+            raise_exp(shellcmd)
+    return True
+
 def lichbd_cluster_stat():
     shellcmd = call_try('lich stat --human-unreadable 2>/dev/null')
     if shellcmd.return_code != 0:


### PR DESCRIPTION
Fix fusionstor clone takes more than 10 seconds issue. It happens after VM was created, when the VM starts first time, in will clone virtual disk's snapshot in backup storage to primary storage. This will took   more than 10 seconds before change. After change it should only take couple of ms.