### PR TITLE
ignore virtlogd start error in case user still use qemu-kvm-2.3

### DIFF
--- a/kvmagent/ansible/kvm.py
+++ b/kvmagent/ansible/kvm.py
@@ -217,7 +217,7 @@ if distro == "RedHat" or distro == "CentOS":
             # name: enable virtlockd daemon on RedHat based OS
             time.sleep(2)
             service_status("virtlockd", "state=started enabled=yes", host_post_info)
-            service_status("virtlogd", "state=started enabled=yes", host_post_info)
+            service_status("virtlogd", "state=started enabled=yes", host_post_info, True)
 
     # name: copy updated dnsmasq for RHEL6 and RHEL7
     copy_arg = CopyArg()


### PR DESCRIPTION
qemu-kvm-2.3 no service virtlogd

for https://github.com/zxwing/premium/issues/1829

Signed-off-by: Mei Lei <meilei007@gmail.com>