### PR TITLE
change minimal memory size to 5946428

### DIFF
--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -1371,8 +1371,8 @@ class StartCmd(Command):
     START_SCRIPT = '../../bin/startup.sh'
     SET_ENV_SCRIPT = '../../bin/setenv.sh'
     MINIMAL_CPU_NUMBER = 4
-    #MINIMAL_MEM_SIZE unit is KB
-    MINIMAL_MEM_SIZE = 6291456
+    #MINIMAL_MEM_SIZE unit is KB, here is 6GB, in linxu, 6GB is 5946428 KB
+    MINIMAL_MEM_SIZE = 594642
 
     def __init__(self):
         super(StartCmd, self).__init__()


### PR DESCRIPTION
In Linux, 6GB is 5946428 KB

Signed-off-by: Mei Lei <meilei007@gmail.com>