### PR TITLE
improve error log

### DIFF
--- a/zstacklib/zstacklib/utils/progress_report.py
+++ b/zstacklib/zstacklib/utils/progress_report.py
@@ -17,8 +17,8 @@ class WatchThread_1(threading.Thread):
         try:
             synced = 0
             while self.keepRunning:
-                time.sleep(1)
                 synced = self.func(synced)
+                time.sleep(1)
         except:
             logger.warning(linux.get_exception_stacktrace())
 


### PR DESCRIPTION
按原来逻辑，如果先sleep，再工作，则最后一次sleep期间如果进度己经结束，就会打印一个找不到文件的错误。
优化掉这个打印