### PR TITLE
Change the actual Memory limitation to 5000MB

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -775,7 +775,8 @@ cs_pre_check(){
             fail "Your system only has $current_cpu CPUs. $PRODUCT_NAME needs at least 4 CPUs."
         fi
         current_memory=`free -m|grep Mem|awk '{print $2}'`
-        if [ $current_memory -lt 5800 ]; then
+        #Save some memory for kdump etc. The actual limitation is 5000MB
+        if [ $current_memory -lt 5000 ]; then
             fail "Your system only has $current_memory MB memory. $PRODUCT_NAME needs at least 6GB memory."
         fi
     fi

--- a/zstackctl/zstackctl/ctl.py
+++ b/zstackctl/zstackctl/ctl.py
@@ -1372,7 +1372,8 @@ class StartCmd(Command):
     SET_ENV_SCRIPT = '../../bin/setenv.sh'
     MINIMAL_CPU_NUMBER = 4
     #MINIMAL_MEM_SIZE unit is KB, here is 6GB, in linxu, 6GB is 5946428 KB
-    MINIMAL_MEM_SIZE = 5946428
+    #Save some memory for kdump etc. The actual limitation is 5000000KB
+    MINIMAL_MEM_SIZE = 5000000
 
     def __init__(self):
         super(StartCmd, self).__init__()


### PR DESCRIPTION
ZStack管理节点的安装和运行对硬件配置的最低要求为4核6GB内存。
但是对于一台实际内存只有6GB的物理机或云主机而言，其实际可用内存值往往低于6GB。
比如如果开启kdump的话，内存中会有一块固定区域被分配出去，无法被ZStack使用。
因此将实际的内存限制定为5000MB。